### PR TITLE
Invoking Watson Natural Language Understanding service from IzODA

### DIFF
--- a/python/Watson_NLU_from_IzODA.ipynb
+++ b/python/Watson_NLU_from_IzODA.ipynb
@@ -1,0 +1,583 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Invoking Watson Natural Language Understanding service from IzODA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IBM Watson Natural Language Understanding will give you results for the features you request.\n",
+    "Natural Language Understanding includes a set of text analytics features that you can use to extract \n",
+    "meaning from unstructured data.\n",
+    "\n",
+    "The standard way of accessing the IBM Watson services programatically requires Watson Developer Cloud Python \n",
+    "SDK to be installed in the system. IzODA does not have Watson Developer Cloud Python SDK yet. However, \n",
+    "it has the library 'requests' available in the anaconda packages.\n",
+    "\n",
+    "This notebook shows how to invoke Watson Natural Language Understanding service from IzODA using 'requests' library. The examples are made based on the examples at https://console.bluemix.net/apidocs/natural-language-understanding"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import the required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define the url, headers and apikey to access Watson NLU Services"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "watson_NLU_url = \"https://gateway.watsonplatform.net/natural-language-understanding/api/v1/analyze?version=2018-11-16\"\n",
+    "headers = {\"Content-Type\": \"application/json\"}\n",
+    "# Fill the apikey from your service credential page\n",
+    "apikey = \"XXXXXXXXXXXXXXXXXXXXXX\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Categories feature\n",
+    "Returns the top three categories of the content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'categories': [{'label': '/technology and computing/operating systems',\n",
+       "   'score': 0.943853},\n",
+       "  {'label': '/technology and computing/hardware/computer', 'score': 0.894139},\n",
+       "  {'label': '/technology and computing/hardware/computer peripherals',\n",
+       "   'score': 0.826798}],\n",
+       " 'language': 'en',\n",
+       " 'retrieved_url': 'https://www.ibm.com/us-en/?ar=1',\n",
+       " 'usage': {'features': 1, 'text_characters': 1671, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Categories_feature = {\n",
+    "  \"url\": \"www.ibm.com\",\n",
+    "  \"features\": {\n",
+    "    \"categories\": {\n",
+    "      \"limit\": 3\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Categories_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Concepts feature\n",
+    "Returns high-level concepts in the content. For example, a research paper about deep learning might return the concept, \"Artificial Intelligence\" although the term is not mentioned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'concepts': [{'dbpedia_resource': 'http://dbpedia.org/resource/Thomas_J._Watson_Research_Center',\n",
+       "   'relevance': 0.907988,\n",
+       "   'text': 'Thomas J. Watson Research Center'},\n",
+       "  {'dbpedia_resource': 'http://dbpedia.org/resource/Thomas_J._Watson',\n",
+       "   'relevance': 0.898525,\n",
+       "   'text': 'Thomas J. Watson'},\n",
+       "  {'dbpedia_resource': 'http://dbpedia.org/resource/Lotus_Software',\n",
+       "   'relevance': 0.896362,\n",
+       "   'text': 'Lotus Software'}],\n",
+       " 'language': 'en',\n",
+       " 'retrieved_url': 'https://www.ibm.com/us-en/?ar=1',\n",
+       " 'usage': {'features': 1, 'text_characters': 1671, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Concepts_feature = {\n",
+    "  \"url\": \"www.ibm.com\",\n",
+    "  \"features\": {\n",
+    "    \"concepts\": {\n",
+    "      \"limit\": 3\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Concepts_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Emotion feature\n",
+    "Detects anger, disgust, fear, joy, or sadness that is conveyed in the content or by the context around target phrases specified in the targets parameter. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'emotion': {'document': {'emotion': {'anger': 0.041796,\n",
+       "    'disgust': 0.022637,\n",
+       "    'fear': 0.033387,\n",
+       "    'joy': 0.563273,\n",
+       "    'sadness': 0.32665}},\n",
+       "  'targets': [{'emotion': {'anger': 0.012855,\n",
+       "     'disgust': 0.017519,\n",
+       "     'fear': 0.02752,\n",
+       "     'joy': 0.859042,\n",
+       "     'sadness': 0.028574},\n",
+       "    'text': 'apples'},\n",
+       "   {'emotion': {'anger': 0.126859,\n",
+       "     'disgust': 0.058103,\n",
+       "     'fear': 0.074223,\n",
+       "     'joy': 0.078317,\n",
+       "     'sadness': 0.514253},\n",
+       "    'text': 'oranges'}]},\n",
+       " 'language': 'en',\n",
+       " 'usage': {'features': 1, 'text_characters': 37, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Emotion_feature = {\n",
+    "  \"html\": \"<html><head><title>Fruits</title></head><body><h1>Apples and Oranges</h1><p>I love apples! I don't like oranges.</p></body></html>\",\n",
+    "  \"features\": {\n",
+    "    \"emotion\": {\n",
+    "      \"targets\": [\n",
+    "        \"apples\",\n",
+    "        \"oranges\"\n",
+    "      ]\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Emotion_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Entities feature\n",
+    "Identifies people, cities, organizations, and other other entities in the content. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'entities': [{'count': 11,\n",
+       "   'disambiguation': {'dbpedia_resource': 'http://dbpedia.org/resource/CNN',\n",
+       "    'name': 'CNN',\n",
+       "    'subtype': ['Broadcast', 'AwardWinner', 'RadioNetwork', 'TVNetwork']},\n",
+       "   'relevance': 0.823356,\n",
+       "   'sentiment': {'label': 'negative', 'score': -0.508488},\n",
+       "   'text': 'CNN',\n",
+       "   'type': 'Company'}],\n",
+       " 'language': 'en',\n",
+       " 'retrieved_url': 'https://www.cnn.com/',\n",
+       " 'usage': {'features': 1, 'text_characters': 2950, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Entities_feature = {\n",
+    "  \"url\": \"www.cnn.com\",\n",
+    "  \"features\": {\n",
+    "    \"entities\": {\n",
+    "      \"sentiment\": True,\n",
+    "      \"limit\": 1\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Entities_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Keywords feature\n",
+    "Returns important keywords in the content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'keywords': [{'count': 1,\n",
+       "   'emotion': {'anger': 0.04746,\n",
+       "    'disgust': 0.023706,\n",
+       "    'fear': 0.070093,\n",
+       "    'joy': 0.045938,\n",
+       "    'sadness': 0.101677},\n",
+       "   'relevance': 0.808759,\n",
+       "   'sentiment': {'label': 'positive', 'score': 0.694942},\n",
+       "   'text': 'IBM\\xa0Global Financing today'},\n",
+       "  {'count': 2,\n",
+       "   'emotion': {'anger': 0.067088,\n",
+       "    'disgust': 0.009997,\n",
+       "    'fear': 0.044807,\n",
+       "    'joy': 0.346924,\n",
+       "    'sadness': 0.025528},\n",
+       "   'relevance': 0.694292,\n",
+       "   'sentiment': {'label': 'positive', 'score': 0.965652},\n",
+       "   'text': 'IBM’s New Collar Certificate'},\n",
+       "  {'count': 1,\n",
+       "   'emotion': {'anger': 0.018987,\n",
+       "    'disgust': 0.007194,\n",
+       "    'fear': 0.016498,\n",
+       "    'joy': 0.134768,\n",
+       "    'sadness': 0.022789},\n",
+       "   'relevance': 0.621547,\n",
+       "   'sentiment': {'label': 'positive', 'score': 0.831308},\n",
+       "   'text': 'IBM Watson'}],\n",
+       " 'language': 'en',\n",
+       " 'retrieved_url': 'https://www.ibm.com/us-en/?ar=1',\n",
+       " 'usage': {'features': 1, 'text_characters': 1671, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Keywords_feature = { \n",
+    "  \"url\": \"www.ibm.com\",\n",
+    "  \"features\": {\n",
+    "    \"keywords\": {\n",
+    "      \"sentiment\": True,\n",
+    "      \"emotion\": True,\n",
+    "      \"limit\": 3\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Keywords_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Metadata feature\n",
+    "Returns information from the document, including author name, title, RSS/ATOM feeds, prominent page image, and publication date. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'language': 'en',\n",
+       " 'metadata': {'authors': [],\n",
+       "  'feeds': [],\n",
+       "  'image': '',\n",
+       "  'publication_date': '2015-10-01T00:00:00',\n",
+       "  'title': 'IBM - United States'},\n",
+       " 'retrieved_url': 'https://www.ibm.com/us-en/?ar=1',\n",
+       " 'usage': {'features': 1, 'text_characters': 1671, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Metadata_feature = {\n",
+    "  \"url\": \"www.ibm.com\",\n",
+    "  \"features\": {\n",
+    "    \"metadata\": {}\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Metadata_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Relations feature\n",
+    "Recognizes when two entities are related and identifies the type of relation. For example, an awardedTo relation might connect the entities \"Nobel Prize\" and \"Albert Einstein\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'language': 'en',\n",
+       " 'relations': [{'arguments': [{'entities': [{'text': 'Best Actor',\n",
+       "       'type': 'EntertainmentAward'}],\n",
+       "     'location': [22, 32],\n",
+       "     'text': 'Best Actor'},\n",
+       "    {'entities': [{'text': 'Leonardo DiCaprio', 'type': 'Person'}],\n",
+       "     'location': [0, 17],\n",
+       "     'text': 'Leonardo DiCaprio'}],\n",
+       "   'score': 0.680715,\n",
+       "   'sentence': 'Leonardo DiCaprio won Best Actor in a Leading Role for his performance.',\n",
+       "   'type': 'awardedTo'}],\n",
+       " 'usage': {'features': 1, 'text_characters': 71, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Relations_feature = {\n",
+    "  \"features\": {\n",
+    "    \"relations\": {}\n",
+    "  },\n",
+    "  \"text\": \"Leonardo DiCaprio won Best Actor in a Leading Role for his performance.\"\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Relations_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Semantic_Roles feature\n",
+    "Parses sentences into subject, action, and object form."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'language': 'en',\n",
+       " 'semantic_roles': [{'action': {'normalized': 'have',\n",
+       "    'text': 'has',\n",
+       "    'verb': {'tense': 'present', 'text': 'have'}},\n",
+       "   'object': {'text': 'one of the largest workforces in the world'},\n",
+       "   'sentence': 'IBM has one of the largest workforces in the world',\n",
+       "   'subject': {'text': 'IBM'}}],\n",
+       " 'usage': {'features': 1, 'text_characters': 50, 'text_units': 1}}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Semantic_Roles_feature = {\n",
+    "  \"features\": {\n",
+    "    \"semantic_roles\": {}\n",
+    "  },\n",
+    "  \"text\": \"IBM has one of the largest workforces in the world\"\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Semantic_Roles_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Sentiment feature\n",
+    "Analyzes the general sentiment of your content or the sentiment toward specific target phrases. You can analyze sentiment for detected entities with entities.sentiment and for keywords with keywords.sentiment \n",
+    "\n",
+    "Note: The following example is currently not working as expected and we reported the issue to the forum https://stackoverflow.com/questions/54274236/sample-example-of-sentiment-feature-of-watson-nlu-failing-with-error-code-400 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'code': 400, 'error': 'target(s) not found', 'language': 'en'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Sentiment_feature = {\n",
+    "  \"url\": \"www.wsj.com/news/markets\",\n",
+    "  \"features\": {\n",
+    "    \"sentiment\": {\n",
+    "       \"targets\": [\n",
+    "          \"company\"\n",
+    "       ]\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "resp = requests.post(watson_NLU_url, data=json.dumps(Sentiment_feature), headers=headers, auth=(\"apikey\",apikey))\n",
+    "resp.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook shows how to invoke Watson Natural Language Understanding
service from IzODA using 'requests' library.

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>