### PR TITLE
Properly set csv flag to switch between csv and odl

### DIFF
--- a/python/client_retention_demo.ipynb
+++ b/python/client_retention_demo.ipynb
@@ -14,8 +14,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use dsdbc, if you have the necessary files virtualized into ODL, simply comment out the next line\n",
-    "csv = \"yes\"\n",
+    "# To use dsdbc, if you have the necessary files virtualized into ODL, simply set csv to False\n",
+    "csv = True\n",
     "\n",
     "if not csv:\n",
     "    import dsdbc #This package required to interface with ODL\n",
@@ -605,7 +605,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Set csv flag to True and False instead of using the string "yes"
and comment out the flag definition.

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>